### PR TITLE
Added fallback for relative units not rendered properly due to iOS7 bug

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1086,32 +1086,32 @@ header .mobile-menu-wrapper button .bars .bar {
 	.intro-container {
 		height: 768px;
 	}
-
-  .intro-container .intro-wrapper .content-wrapper {
-    transform: translate(-50%, -50%);
-    margin: 0;
-    position: absolute;
-    top: 15%;
-    left: 0%;
-    width: 100%;
-    text-align: center;
-  }
+	
+	.intro-container .intro-wrapper .content-wrapper {
+		transform: translate(-50%, -50%);
+		margin: 0;
+		position: absolute;
+		top: 15%;
+		left: 0%;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 @media only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : portrait) {
 	.intro-container {
 		height: 1024px;
 	}
-
-  .intro-container .intro-wrapper .content-wrapper {
-    transform: translate(-50%, -50%);
-    margin: 0;
-    position: absolute;
-    top: 15%;
-    left: 0%;
-    width: 100%;
-    text-align: center;
-  }
+	
+	.intro-container .intro-wrapper .content-wrapper {
+		transform: translate(-50%, -50%);
+		margin: 0;
+		position: absolute;
+		top: 15%;
+		left: 0%;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 /* iphone5 */
@@ -1119,32 +1119,32 @@ header .mobile-menu-wrapper button .bars .bar {
 	.intro-container {
 		height: 320px;
 	}
-
-  .intro-container .intro-wrapper .content-wrapper {
-    transform: translate(-50%, -50%);
-    margin: 0;
-    position: absolute;
-    top: 15%;
-    left: 0%;
-    width: 100%;
-    text-align: center;
-  }
+	
+	.intro-container .intro-wrapper .content-wrapper {
+		transform: translate(-50%, -50%);
+		margin: 0;
+		position: absolute;
+		top: 15%;
+		left: 0%;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 @media only screen and (min-device-width: 320px) and (max-device-height: 568px) and (orientation : portrait) and (-webkit-device-pixel-ratio: 2) {
 	.intro-container {
 		height: 568px;
 	}
-
-  .intro-container .intro-wrapper .content-wrapper {
-    transform: translate(-50%, -50%);
-    margin: 0;
-    position: absolute;
-    top: 15%;
-    left: 0%;
-    width: 100%;
-    text-align: center;
-  }
+	
+	.intro-container .intro-wrapper .content-wrapper {
+		transform: translate(-50%, -50%);
+		margin: 0;
+		position: absolute;
+		top: 15%;
+		left: 0%;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 /* iPhone 4 */
@@ -1152,32 +1152,32 @@ header .mobile-menu-wrapper button .bars .bar {
 	.intro-container {
 		height: 320px;
 	}
-
-  .intro-container .intro-wrapper .content-wrapper {
-    transform: translate(-50%, -50%);
-    margin: 0;
-    position: absolute;
-    top: 15%;
-    left: 0%;
-    width: 100%;
-    text-align: center;
-  }
+	
+	.intro-container .intro-wrapper .content-wrapper {
+		transform: translate(-50%, -50%);
+		margin: 0;
+		position: absolute;
+		top: 15%;
+		left: 0%;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 @media only screen and (min-device-width : 320px) and (max-device-width : 480px) and (orientation : portrait) and (-webkit-min-device-pixel-ratio : 2) {
 	.intro-container {
 		height: 480px;
 	}
-
-  .intro-container .intro-wrapper .content-wrapper {
-    transform: translate(-50%, -50%);
-    margin: 0;
-    position: absolute;
-    top: 15%;
-    left: 0%;
-    width: 100%;
-    text-align: center;
-  }
+	
+	.intro-container .intro-wrapper .content-wrapper {
+		transform: translate(-50%, -50%);
+		margin: 0;
+		position: absolute;
+		top: 15%;
+		left: 0%;
+		width: 100%;
+		text-align: center;
+	}
 }
 
 @media (max-width: 1099px) {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1080,6 +1080,106 @@ header .mobile-menu-wrapper button .bars .bar {
   transform: rotate(-45deg);
 }
 
+/* iOS6 & iOS7 relative units fallback */
+/* ipad */
+@media only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : landscape) {
+	.intro-container {
+		height: 768px;
+	}
+
+  .intro-container .intro-wrapper .content-wrapper {
+    transform: translate(-50%, -50%);
+    margin: 0;
+    position: absolute;
+    top: 15%;
+    left: 0%;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : portrait) {
+	.intro-container {
+		height: 1024px;
+	}
+
+  .intro-container .intro-wrapper .content-wrapper {
+    transform: translate(-50%, -50%);
+    margin: 0;
+    position: absolute;
+    top: 15%;
+    left: 0%;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+/* iphone5 */
+@media only screen and (min-device-width: 320px) and (max-device-height: 568px) and (orientation : landscape) and (-webkit-device-pixel-ratio: 2) {
+	.intro-container {
+		height: 320px;
+	}
+
+  .intro-container .intro-wrapper .content-wrapper {
+    transform: translate(-50%, -50%);
+    margin: 0;
+    position: absolute;
+    top: 15%;
+    left: 0%;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media only screen and (min-device-width: 320px) and (max-device-height: 568px) and (orientation : portrait) and (-webkit-device-pixel-ratio: 2) {
+	.intro-container {
+		height: 568px;
+	}
+
+  .intro-container .intro-wrapper .content-wrapper {
+    transform: translate(-50%, -50%);
+    margin: 0;
+    position: absolute;
+    top: 15%;
+    left: 0%;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+/* iPhone 4 */
+@media only screen and (min-device-width : 320px) and (max-device-width : 480px) and (orientation : landscape) and (-webkit-min-device-pixel-ratio : 2) {
+	.intro-container {
+		height: 320px;
+	}
+
+  .intro-container .intro-wrapper .content-wrapper {
+    transform: translate(-50%, -50%);
+    margin: 0;
+    position: absolute;
+    top: 15%;
+    left: 0%;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media only screen and (min-device-width : 320px) and (max-device-width : 480px) and (orientation : portrait) and (-webkit-min-device-pixel-ratio : 2) {
+	.intro-container {
+		height: 480px;
+	}
+
+  .intro-container .intro-wrapper .content-wrapper {
+    transform: translate(-50%, -50%);
+    margin: 0;
+    position: absolute;
+    top: 15%;
+    left: 0%;
+    width: 100%;
+    text-align: center;
+  }
+}
+
 @media (max-width: 1099px) {
   .intro-container .intro-wrapper .content-wrapper img {
     max-height: 170px;


### PR DESCRIPTION
iOS 7 does not render relative units well. Setting a height of 100vh creates a large gap and may cause the browser the crash.

More information: https://github.com/scottjehl/Device-Bugs/issues/36

**Before:**
![photo 1](https://cloud.githubusercontent.com/assets/8150534/23021216/45438812-f464-11e6-82da-8d51f9b4c923.PNG)

**After:**
![photo 2](https://cloud.githubusercontent.com/assets/8150534/23021219/4f552676-f464-11e6-88a9-d148edbb6654.PNG)

